### PR TITLE
Fixed an issue with Unity 2021_3_24_f1

### DIFF
--- a/package/Editor/CustomConsole/ConsoleList.cs
+++ b/package/Editor/CustomConsole/ConsoleList.cs
@@ -538,7 +538,7 @@ namespace Needle.Console
 			try
 			{
 #if UNITY_CONSOLE_STACKTRACE_TWO_PARAMETERS
-#if UNITY_2022_2_OR_NEWER
+#if UNITY_2021_3_24_OR_NEWER
 				// mode doesn't matter when shouldStripCallstack is false
 				var stackWithHyperlinks = ConsoleWindow.StacktraceWithHyperlinks(message, 0, false, ConsoleWindow.Mode.Log);
 #else

--- a/package/Editor/CustomConsole/needle.Demystify.Console.asmdef
+++ b/package/Editor/CustomConsole/needle.Demystify.Console.asmdef
@@ -40,6 +40,10 @@
             "name": "Unity",
             "expression": "[2020.3.38,9999.9)",
             "define": "UNITY_2020_3_38_OR_NEWER"
+        },
+        {   "name": "Unity",
+            "expression": "[2021.3.24,9999.9)",
+            "define": "UNITY_2021_3_24_OR_NEWER"
         }
     ],
     "noEngineReferences": false

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Needle Console",
   "name": "com.needle.console",
-  "version": "2.3.15",
+  "version": "2.3.16",
   "unity": "2020.3",
   "description": "Better Unity console featuring improved stacktrace readability using Ben.Demystifier, filtering of log entries, collapsing of individual logs",
   "keywords": [


### PR DESCRIPTION
- The asm def UNITY_2022_2_OR_NEWER was not  defined (?)
- Added to needle.Demystify.Console.asmdef #UNITY_2021_3_24_OR_NEWER
- Served myself and bumped package version to `2.3.16`
_(First PR ever, am I a pro now ? 😄 )_ 